### PR TITLE
opt-in

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -213,8 +213,12 @@ class NotificationService
         end
       end
 
-      # Send SMS if recipient can receive this type
-      if recipient.respond_to?(:can_receive_sms?) && recipient.can_receive_sms?(sms_type)
+      # Attempt to send SMS regardless of current opt-in state. SmsService will
+      # internally decide whether to actually deliver the message or enqueue an
+      # opt-in invitation. This change ensures customers who are not yet opted
+      # in will still receive an invitation flow rather than silently skipping
+      # SMS entirely.
+      if recipient.respond_to?(:phone)
         begin
           sms_result = sms.call
           # Handle various SMS result formats more robustly

--- a/spec/services/notification_service_spec.rb
+++ b/spec/services/notification_service_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe NotificationService, type: :service do
 
       it 'sends only email notification' do
         expect(BookingMailer).to receive(:confirmation).with(booking)
-        expect(SmsService).not_to receive(:send_booking_confirmation)
+        expect(SmsService).to receive(:send_booking_confirmation).with(booking).and_return({ success: false })
         
         NotificationService.booking_confirmation(booking)
       end
@@ -56,9 +56,11 @@ RSpec.describe NotificationService, type: :service do
 
       it 'does not send any notifications' do
         expect(BookingMailer).not_to receive(:confirmation)
-        expect(SmsService).not_to receive(:send_booking_confirmation)
+        expect(SmsService).to receive(:send_booking_confirmation).with(booking).and_return({ success: false })
         
-        NotificationService.booking_confirmation(booking)
+        result = NotificationService.booking_confirmation(booking)
+        expect(result[:email]).to be false
+        expect(result[:sms]).to be false
       end
     end
 
@@ -135,7 +137,7 @@ RSpec.describe NotificationService, type: :service do
 
       it 'sends only email marketing' do
         expect(MarketingMailer).to receive(:campaign).with(customer, campaign)
-        expect(SmsService).not_to receive(:send_marketing_campaign)
+        expect(SmsService).to receive(:send_marketing_campaign).with(campaign, customer).and_return({ success: false })
         
         NotificationService.marketing_campaign(campaign, customer)
       end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> NotificationService now always attempts SMS via SmsService (based on presence of phone), delegating opt-in logic to SmsService, with updated result parsing/logging and corresponding spec updates.
> 
> - **Notifications**:
>   - Attempt SMS for any recipient with `phone`, removing `can_receive_sms?` gate; delegate opt-in/invitation logic to `SmsService`.
>   - More robust SMS result handling (`Hash`, `true`, others as failure) with updated logging for non-sent cases.
> - **Tests**:
>   - Update specs to expect `SmsService` to be invoked even when SMS is not allowed/opted-in and to assert `{ success: false }` paths and returned `results` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a9a284a0066a51465ad657f2e11089ca0f4fe4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->