### PR TITLE
opt-in-queue

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -51,7 +51,7 @@ module Public
       begin
         linker = CustomerLinker.new(current_tenant)
         customer = linker.link_user_to_customer(current_user)
-      rescue CustomerLinker::EmailConflictError => e
+      rescue EmailConflictError => e
         Rails.logger.error "[OrdersController#create] CustomerLinker error for user #{current_user.id}: #{e.message}"
         flash[:alert] = e.message
         redirect_to new_order_path and return

--- a/app/controllers/public/subscriptions_controller.rb
+++ b/app/controllers/public/subscriptions_controller.rb
@@ -183,7 +183,7 @@ class Public::SubscriptionsController < Public::BaseController
       begin
         linker = CustomerLinker.new(current_business)
         linker.link_user_to_customer(current_user)
-      rescue CustomerLinker::EmailConflictError => e
+      rescue EmailConflictError => e
         Rails.logger.error "[SubscriptionsController#find_or_create] CustomerLinker error for user #{current_user.id}: #{e.message}"
         return nil
       rescue StandardError => e

--- a/app/jobs/sms_notification_replay_job.rb
+++ b/app/jobs/sms_notification_replay_job.rb
@@ -7,8 +7,8 @@ class SmsNotificationReplayJob < ApplicationJob
   # Don't retry for permanent failures
   discard_on ArgumentError, ActiveRecord::RecordNotFound
 
-  def perform(customer_id, business_id = nil)
-    Rails.logger.info "[SMS_REPLAY_JOB] Starting job for customer #{customer_id}, business #{business_id || 'all'}"
+  def perform(customer_id, business_id = nil, retry_count = 0)
+    Rails.logger.info "[SMS_REPLAY_JOB] Starting job for customer #{customer_id}, business #{business_id || 'all'}, retry #{retry_count}"
 
     customer = TenantCustomer.find(customer_id)
     business = business_id ? Business.find(business_id) : nil
@@ -31,10 +31,21 @@ class SmsNotificationReplayJob < ApplicationJob
     # Log results for monitoring
     Rails.logger.info "[SMS_REPLAY_JOB] Completed for customer #{customer_id}: #{results}"
 
-    # If there are rate-limited notifications, schedule a retry job
+    # If there are rate-limited notifications, schedule a retry job with delay
     if results[:rate_limited] > 0
-      Rails.logger.info "[SMS_REPLAY_JOB] Scheduling retry for #{results[:rate_limited]} rate-limited notifications"
-      self.class.perform_later(customer_id, business_id)
+      # Prevent infinite loops - max 5 retries
+      if retry_count >= 5
+        Rails.logger.error "[SMS_REPLAY_JOB] Max retries (#{retry_count}) reached for customer #{customer_id}, abandoning #{results[:rate_limited]} rate-limited notifications"
+        # Mark abandoned notifications as failed to prevent future retries
+        mark_abandoned_notifications_as_failed(customer, business)
+        return results
+      end
+
+      # Calculate retry delay based on attempt number
+      delay = calculate_retry_delay(retry_count)
+      Rails.logger.info "[SMS_REPLAY_JOB] Scheduling retry #{retry_count + 1} for #{results[:rate_limited]} rate-limited notifications in #{delay}"
+
+      self.class.perform_in(delay, customer_id, business_id, retry_count + 1)
     end
 
     results
@@ -49,13 +60,48 @@ class SmsNotificationReplayJob < ApplicationJob
 
   # Class method to schedule replay for a customer
   def self.schedule_for_customer(customer, business = nil)
-    perform_later(customer.id, business&.id)
+    perform_later(customer.id, business&.id, 0) # Start with retry_count = 0
     Rails.logger.info "[SMS_REPLAY_JOB] Scheduled replay for customer #{customer.id}, business #{business&.id || 'all'}"
   end
 
   # Class method to schedule replay with delay (useful for rate limiting)
   def self.schedule_for_customer_delayed(customer, business = nil, delay: 1.hour)
-    perform_in(delay, customer.id, business&.id)
+    perform_in(delay, customer.id, business&.id, 0) # Start with retry_count = 0
     Rails.logger.info "[SMS_REPLAY_JOB] Scheduled delayed replay (#{delay}) for customer #{customer.id}, business #{business&.id || 'all'}"
+  end
+
+  private
+
+  # Calculate exponential backoff delay for rate-limited retries
+  def calculate_retry_delay(retry_count)
+    case retry_count
+    when 0
+      15.minutes  # First retry: 15 minutes (might be temporary burst)
+    when 1
+      1.hour      # Second retry: 1 hour (likely hourly rate limit)
+    when 2
+      4.hours     # Third retry: 4 hours (might be daily limit partially reset)
+    when 3
+      12.hours    # Fourth retry: 12 hours (daily limit should reset soon)
+    else
+      24.hours    # Final retry: 24 hours (full daily reset)
+    end
+  end
+
+  # Mark rate-limited notifications as failed when max retries reached
+  def mark_abandoned_notifications_as_failed(customer, business)
+    scope = if business
+      PendingSmsNotification.pending.for_customer(customer).for_business(business)
+    else
+      PendingSmsNotification.pending.for_customer(customer)
+    end
+
+    abandoned_count = scope.count
+    if abandoned_count > 0
+      scope.find_each do |notification|
+        notification.mark_as_failed!("Abandoned after max retries due to persistent rate limiting")
+      end
+      Rails.logger.warn "[SMS_REPLAY_JOB] Marked #{abandoned_count} notifications as failed for customer #{customer.id} due to max retries"
+    end
   end
 end

--- a/app/jobs/sms_notification_replay_job.rb
+++ b/app/jobs/sms_notification_replay_job.rb
@@ -1,0 +1,61 @@
+class SmsNotificationReplayJob < ApplicationJob
+  queue_as :default
+
+  # Retry with exponential backoff for transient failures
+  retry_on StandardError, wait: :exponentially_longer, attempts: 3
+
+  # Don't retry for permanent failures
+  discard_on ArgumentError, ActiveRecord::RecordNotFound
+
+  def perform(customer_id, business_id = nil)
+    Rails.logger.info "[SMS_REPLAY_JOB] Starting job for customer #{customer_id}, business #{business_id || 'all'}"
+
+    customer = TenantCustomer.find(customer_id)
+    business = business_id ? Business.find(business_id) : nil
+
+    # Verify customer can receive SMS before processing
+    unless customer.phone_opt_in?
+      Rails.logger.warn "[SMS_REPLAY_JOB] Customer #{customer_id} is not opted in for SMS, skipping replay"
+      return
+    end
+
+    # If business-specific, verify customer can receive SMS from that business
+    if business && customer.opted_out_from_business?(business)
+      Rails.logger.warn "[SMS_REPLAY_JOB] Customer #{customer_id} is opted out from business #{business_id}, skipping replay"
+      return
+    end
+
+    # Process the pending notifications
+    results = SmsNotificationReplayService.replay_for_customer(customer, business)
+
+    # Log results for monitoring
+    Rails.logger.info "[SMS_REPLAY_JOB] Completed for customer #{customer_id}: #{results}"
+
+    # If there are rate-limited notifications, schedule a retry job
+    if results[:rate_limited] > 0
+      Rails.logger.info "[SMS_REPLAY_JOB] Scheduling retry for #{results[:rate_limited]} rate-limited notifications"
+      self.class.perform_later(customer_id, business_id)
+    end
+
+    results
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "[SMS_REPLAY_JOB] Record not found: #{e.message}"
+    raise # This will be discarded due to discard_on above
+  rescue => e
+    Rails.logger.error "[SMS_REPLAY_JOB] Error processing customer #{customer_id}: #{e.message}"
+    Rails.logger.error e.backtrace.join("\n")
+    raise # This will be retried due to retry_on above
+  end
+
+  # Class method to schedule replay for a customer
+  def self.schedule_for_customer(customer, business = nil)
+    perform_later(customer.id, business&.id)
+    Rails.logger.info "[SMS_REPLAY_JOB] Scheduled replay for customer #{customer.id}, business #{business&.id || 'all'}"
+  end
+
+  # Class method to schedule replay with delay (useful for rate limiting)
+  def self.schedule_for_customer_delayed(customer, business = nil, delay: 1.hour)
+    perform_in(delay, customer.id, business&.id)
+    Rails.logger.info "[SMS_REPLAY_JOB] Scheduled delayed replay (#{delay}) for customer #{customer.id}, business #{business&.id || 'all'}"
+  end
+end

--- a/app/models/pending_sms_notification.rb
+++ b/app/models/pending_sms_notification.rb
@@ -1,0 +1,180 @@
+class PendingSmsNotification < ApplicationRecord
+  # Associations
+  belongs_to :business
+  belongs_to :tenant_customer
+  belongs_to :booking, optional: true
+  belongs_to :invoice, optional: true
+  belongs_to :order, optional: true
+
+  # Validations
+  validates :notification_type, presence: true
+  validates :sms_type, presence: true
+  validates :template_data, presence: true
+  validates :phone_number, presence: true, format: { with: /\A\+?[1-9]\d{1,14}\z/ }
+  validates :queued_at, presence: true
+  validates :expires_at, presence: true
+  validates :deduplication_key, presence: true, uniqueness: true
+  validates :status, presence: true, inclusion: { in: %w[pending sent failed expired] }
+
+  # Status enum (for better querying)
+  enum :status, {
+    pending: 'pending',
+    sent: 'sent',
+    failed: 'failed',
+    expired: 'expired'
+  }
+
+  # Scopes for common queries
+  scope :pending, -> { where(status: 'pending') }
+  scope :expired, -> { where('expires_at < ?', Time.current) }
+  scope :not_expired, -> { where('expires_at >= ?', Time.current) }
+  scope :for_customer, ->(customer) { where(tenant_customer: customer) }
+  scope :for_business, ->(business) { where(business: business) }
+  scope :for_notification_type, ->(type) { where(notification_type: type) }
+  scope :ready_for_processing, -> { pending.not_expired.order(:queued_at) }
+
+  # Class methods for creating notifications
+  def self.queue_notification(notification_type:, customer:, business:, sms_type:, template_data:, **associations)
+    # Generate deduplication key to prevent duplicate queuing
+    dedup_key = generate_deduplication_key(
+      notification_type: notification_type,
+      customer_id: customer.id,
+      business_id: business.id,
+      associations: associations
+    )
+
+    # Check if this notification is already queued
+    existing = find_by(deduplication_key: dedup_key)
+    if existing&.pending?
+      Rails.logger.info "[PENDING_SMS] Notification already queued: #{dedup_key}"
+      return existing
+    end
+
+    # Create new pending notification
+    notification = create!(
+      business: business,
+      tenant_customer: customer,
+      notification_type: notification_type.to_s,
+      sms_type: sms_type.to_s,
+      template_data: template_data,
+      phone_number: customer.phone,
+      queued_at: Time.current,
+      expires_at: 7.days.from_now, # Auto-expire after 7 days
+      deduplication_key: dedup_key,
+      status: 'pending',
+      **associations.slice(:booking, :invoice, :order)
+    )
+
+    Rails.logger.info "[PENDING_SMS] Queued #{notification_type} for customer #{customer.id} (business #{business.id})"
+    notification
+  rescue ActiveRecord::RecordNotUnique
+    # Handle race condition where duplicate was created between check and create
+    find_by!(deduplication_key: dedup_key)
+  end
+
+  # Queue booking-related notifications
+  def self.queue_booking_notification(notification_type, booking, template_data)
+    queue_notification(
+      notification_type: notification_type,
+      customer: booking.tenant_customer,
+      business: booking.business,
+      sms_type: 'booking',
+      template_data: template_data,
+      booking: booking
+    )
+  end
+
+  # Queue invoice-related notifications
+  def self.queue_invoice_notification(notification_type, invoice, template_data)
+    queue_notification(
+      notification_type: notification_type,
+      customer: invoice.tenant_customer,
+      business: invoice.business,
+      sms_type: 'payment',
+      template_data: template_data,
+      invoice: invoice
+    )
+  end
+
+  # Queue order-related notifications
+  def self.queue_order_notification(notification_type, order, template_data)
+    queue_notification(
+      notification_type: notification_type,
+      customer: order.tenant_customer,
+      business: order.business,
+      sms_type: 'order',
+      template_data: template_data,
+      order: order
+    )
+  end
+
+  # Mark notification as sent
+  def mark_as_sent!
+    update!(
+      status: 'sent',
+      processed_at: Time.current,
+      failed_at: nil,
+      failure_reason: nil
+    )
+    Rails.logger.info "[PENDING_SMS] Marked notification #{id} as sent"
+  end
+
+  # Mark notification as failed
+  def mark_as_failed!(reason)
+    update!(
+      status: 'failed',
+      failed_at: Time.current,
+      failure_reason: reason
+    )
+    Rails.logger.error "[PENDING_SMS] Marked notification #{id} as failed: #{reason}"
+  end
+
+  # Mark notification as expired
+  def mark_as_expired!
+    update!(status: 'expired')
+    Rails.logger.info "[PENDING_SMS] Marked notification #{id} as expired"
+  end
+
+  # Check if notification is expired
+  def expired?
+    expires_at < Time.current
+  end
+
+  # Get notification age in days
+  def age_in_days
+    (Time.current - queued_at) / 1.day
+  end
+
+  # Clean up expired notifications
+  def self.cleanup_expired!
+    expired_count = expired.update_all(status: 'expired')
+    Rails.logger.info "[PENDING_SMS] Marked #{expired_count} notifications as expired" if expired_count > 0
+    expired_count
+  end
+
+  # Get statistics for monitoring
+  def self.stats
+    {
+      pending: pending.count,
+      expired: expired.count,
+      total: count,
+      oldest_pending: pending.minimum(:queued_at),
+      newest_pending: pending.maximum(:queued_at)
+    }
+  end
+
+  private
+
+  # Generate unique deduplication key
+  def self.generate_deduplication_key(notification_type:, customer_id:, business_id:, associations:)
+    # Include relevant association IDs in the key
+    association_part = associations.compact.map { |k, v| "#{k}:#{v.id}" }.sort.join("|")
+
+    base_key = "#{notification_type}:#{business_id}:#{customer_id}"
+    base_key += ":#{association_part}" if association_part.present?
+
+    # Add timestamp component to allow re-queuing after reasonable time (24 hours)
+    time_bucket = (Time.current.to_i / 24.hours).to_i
+    "#{base_key}:#{time_bucket}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -767,11 +767,13 @@ class User < ApplicationRecord
         # Update phone if customer doesn't have one or if different
         if customer.phone.blank? || customer.phone != phone
           updates[:phone] = phone
-          
-          # Set opt-in if user has opted in and customer hasn't
-          if respond_to?(:phone_opt_in?) && phone_opt_in? && !customer.phone_opt_in?                                                                             
-            updates[:phone_opt_in] = true
-            updates[:phone_opt_in_at] = respond_to?(:phone_opt_in_at) ? phone_opt_in_at : Time.current                                                           
+
+          # Sync opt-in status from user when phone changes (TCPA compliance)
+          if respond_to?(:phone_opt_in?) && customer.phone_opt_in? != phone_opt_in?
+            updates[:phone_opt_in] = phone_opt_in?
+            updates[:phone_opt_in_at] = phone_opt_in? ?
+              (respond_to?(:phone_opt_in_at) ? phone_opt_in_at : Time.current) :
+              nil
           end
         end
         

--- a/app/services/referral_service.rb
+++ b/app/services/referral_service.rb
@@ -89,7 +89,7 @@ class ReferralService
       # For now, referral customers are created without special notification handling
 
       customer
-    rescue CustomerLinker::EmailConflictError => e
+    rescue EmailConflictError => e
       Rails.logger.error "[ReferralService] CustomerLinker error for user #{user.id}: #{e.message}"
       raise e
     rescue StandardError => e

--- a/app/services/sms_notification_replay_service.rb
+++ b/app/services/sms_notification_replay_service.rb
@@ -1,0 +1,193 @@
+class SmsNotificationReplayService
+  # Service for replaying pending SMS notifications when customers opt in
+
+  class << self
+    # Replay all pending notifications for a customer who just opted in
+    def replay_for_customer(customer, business = nil)
+      Rails.logger.info "[SMS_REPLAY] Starting replay for customer #{customer.id}"
+
+      # Find pending notifications for this customer
+      notifications = if business
+        # Business-specific opt-in: only replay notifications for that business
+        PendingSmsNotification.ready_for_processing
+                             .for_customer(customer)
+                             .for_business(business)
+      else
+        # Global opt-in: replay all pending notifications
+        PendingSmsNotification.ready_for_processing
+                             .for_customer(customer)
+      end
+
+      results = {
+        total: notifications.count,
+        sent: 0,
+        failed: 0,
+        expired: 0,
+        rate_limited: 0
+      }
+
+      Rails.logger.info "[SMS_REPLAY] Found #{results[:total]} pending notifications for customer #{customer.id}"
+
+      return results if results[:total] == 0
+
+      # Process notifications one by one, respecting rate limits
+      notifications.find_each do |notification|
+        result = process_notification(notification)
+        results[result] += 1
+
+        # Add small delay between sends to respect rate limits
+        sleep(0.5) if result == :sent
+      end
+
+      Rails.logger.info "[SMS_REPLAY] Completed replay for customer #{customer.id}: #{results}"
+      results
+    end
+
+    # Process a single pending notification
+    def process_notification(notification)
+      # Double-check the notification is still valid
+      if notification.expired?
+        notification.mark_as_expired!
+        return :expired
+      end
+
+      unless notification.pending?
+        Rails.logger.warn "[SMS_REPLAY] Notification #{notification.id} is not pending (status: #{notification.status})"
+        return :failed
+      end
+
+      # Verify customer can now receive SMS
+      customer = notification.tenant_customer
+      unless customer.can_receive_sms?(notification.sms_type.to_sym)
+        Rails.logger.warn "[SMS_REPLAY] Customer #{customer.id} still cannot receive #{notification.sms_type} SMS"
+        notification.mark_as_failed!("Customer still not opted in for #{notification.sms_type} SMS")
+        return :failed
+      end
+
+      # Check business can still send SMS
+      business = notification.business
+      unless business.can_send_sms?
+        Rails.logger.warn "[SMS_REPLAY] Business #{business.id} can no longer send SMS"
+        notification.mark_as_failed!("Business no longer supports SMS")
+        return :failed
+      end
+
+      # Check rate limits
+      unless SmsRateLimiter.can_send?(business, customer)
+        Rails.logger.info "[SMS_REPLAY] Rate limit exceeded for business #{business.id}, customer #{customer.id}"
+        return :rate_limited
+      end
+
+      # Render the SMS message using the stored template data
+      message = render_message(notification)
+      unless message
+        notification.mark_as_failed!("Failed to render SMS message template")
+        return :failed
+      end
+
+      # Send the SMS
+      result = SmsService.send_message(
+        notification.phone_number,
+        message,
+        build_sms_options(notification)
+      )
+
+      if result[:success]
+        # Record the send for rate limiting
+        SmsRateLimiter.record_send(business, customer)
+        notification.mark_as_sent!
+        Rails.logger.info "[SMS_REPLAY] Successfully sent #{notification.notification_type} to #{customer.id}"
+        :sent
+      else
+        notification.mark_as_failed!(result[:error] || "Unknown SMS sending error")
+        Rails.logger.error "[SMS_REPLAY] Failed to send #{notification.notification_type} to #{customer.id}: #{result[:error]}"
+        :failed
+      end
+
+    rescue => e
+      notification.mark_as_failed!("Exception during processing: #{e.message}")
+      Rails.logger.error "[SMS_REPLAY] Exception processing notification #{notification.id}: #{e.message}"
+      Rails.logger.error e.backtrace.join("\n")
+      :failed
+    end
+
+    # Cleanup expired notifications (can be called periodically)
+    def cleanup_expired!
+      PendingSmsNotification.cleanup_expired!
+    end
+
+    # Get statistics for monitoring
+    def stats
+      PendingSmsNotification.stats
+    end
+
+    private
+
+    # Render SMS message using the notification's template data
+    def render_message(notification)
+      template_name = notification_type_to_template(notification.notification_type)
+      return nil unless template_name
+
+      template_data = notification.template_data.is_a?(String) ?
+                      JSON.parse(notification.template_data) :
+                      notification.template_data
+
+      Sms::MessageTemplates.render(template_name, template_data.symbolize_keys)
+    rescue => e
+      Rails.logger.error "[SMS_REPLAY] Failed to render template for #{notification.notification_type}: #{e.message}"
+      nil
+    end
+
+    # Map notification types to SMS template names
+    def notification_type_to_template(notification_type)
+      case notification_type
+      when 'booking_confirmation'
+        'booking.confirmation'
+      when 'booking_reminder'
+        'booking.reminder'
+      when 'booking_status_update'
+        'booking.status_update'
+      when 'booking_cancellation'
+        'booking.cancellation'
+      when 'booking_payment_reminder'
+        'booking.payment_reminder'
+      when 'invoice_created'
+        'invoice.created'
+      when 'invoice_payment_confirmation'
+        'invoice.payment_confirmation'
+      when 'invoice_payment_reminder'
+        'invoice.payment_reminder'
+      when 'invoice_payment_failed'
+        'invoice.payment_failed'
+      when 'order_confirmation'
+        'order.confirmation'
+      when 'order_status_update'
+        'order.status_update'
+      when 'order_refund_confirmation'
+        'order.refund_confirmation'
+      when 'subscription_booking_created'
+        'booking.subscription_booking_created'
+      when 'subscription_order_created'
+        'order.subscription_order_created'
+      else
+        Rails.logger.error "[SMS_REPLAY] Unknown notification type: #{notification_type}"
+        nil
+      end
+    end
+
+    # Build options hash for SmsService.send_message
+    def build_sms_options(notification)
+      options = {
+        business_id: notification.business_id,
+        tenant_customer_id: notification.tenant_customer_id
+      }
+
+      # Add specific association IDs if present
+      options[:booking_id] = notification.booking_id if notification.booking_id
+      options[:invoice_id] = notification.invoice_id if notification.invoice_id
+      options[:order_id] = notification.order_id if notification.order_id
+
+      options
+    end
+  end
+end

--- a/app/services/sms_service.rb
+++ b/app/services/sms_service.rb
@@ -212,7 +212,25 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless booking.tenant_customer.can_receive_sms?(:booking)
       Rails.logger.info "[SMS_SERVICE] Customer #{booking.tenant_customer.id} not opted in for cancellation SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(booking.tenant_customer, booking.business, :booking_cancellation)
+        send_opt_in_invitation(booking.tenant_customer, booking.business, :booking_cancellation)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_booking_variables(booking)
+      variables[:reason] = booking.cancellation_reason || 'No reason provided'
+      variables[:link] = generate_sms_link(booking.business, "/services", booking_id: booking.id)
+
+      queued_notification = PendingSmsNotification.queue_booking_notification(
+        'booking_cancellation',
+        booking,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued booking cancellation for customer #{booking.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_booking_variables(booking)
@@ -236,7 +254,25 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless booking.tenant_customer.can_receive_sms?(:payment)
       Rails.logger.info "[SMS_SERVICE] Customer #{booking.tenant_customer.id} not opted in for payment reminder SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(booking.tenant_customer, booking.business, :booking_payment_reminder)
+        send_opt_in_invitation(booking.tenant_customer, booking.business, :booking_payment_reminder)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_booking_variables(booking)
+      variables[:amount] = format_currency(booking.invoice&.amount || booking.total_amount)
+      variables[:link] = generate_sms_link(booking.business, "/booking/#{booking.id}/pay", booking_id: booking.id)
+
+      queued_notification = PendingSmsNotification.queue_booking_notification(
+        'booking_payment_reminder',
+        booking,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued booking payment reminder for customer #{booking.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_booking_variables(booking)
@@ -260,7 +296,24 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless booking.tenant_customer.can_receive_sms?(:subscription)
       Rails.logger.info "[SMS_SERVICE] Customer #{booking.tenant_customer.id} not opted in for subscription SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(booking.tenant_customer, booking.business, :subscription_booking_created)
+        send_opt_in_invitation(booking.tenant_customer, booking.business, :subscription_booking_created)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_booking_variables(booking)
+      variables[:link] = generate_sms_link(booking.business, "/booking/#{booking.id}/confirmation", booking_id: booking.id)
+
+      queued_notification = PendingSmsNotification.queue_booking_notification(
+        'subscription_booking_created',
+        booking,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued subscription booking created for customer #{booking.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_booking_variables(booking)
@@ -319,7 +372,25 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless invoice.tenant_customer.can_receive_sms?(:payment)
       Rails.logger.info "[SMS_SERVICE] Customer #{invoice.tenant_customer.id} not opted in for payment confirmation SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(invoice.tenant_customer, invoice.business, :invoice_payment_confirmation)
+        send_opt_in_invitation(invoice.tenant_customer, invoice.business, :invoice_payment_confirmation)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_invoice_variables(invoice)
+      variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}", invoice_id: invoice.id)
+      variables[:payment_id] = payment.id if payment
+
+      queued_notification = PendingSmsNotification.queue_invoice_notification(
+        'invoice_payment_confirmation',
+        invoice,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued invoice payment confirmation for customer #{invoice.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_invoice_variables(invoice)
@@ -342,7 +413,25 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless invoice.tenant_customer.can_receive_sms?(:payment)
       Rails.logger.info "[SMS_SERVICE] Customer #{invoice.tenant_customer.id} not opted in for payment reminder SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(invoice.tenant_customer, invoice.business, :invoice_payment_reminder)
+        send_opt_in_invitation(invoice.tenant_customer, invoice.business, :invoice_payment_reminder)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_invoice_variables(invoice)
+      variables[:days_overdue] = (Date.current - invoice.due_date).to_i
+      variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}/pay", invoice_id: invoice.id)
+
+      queued_notification = PendingSmsNotification.queue_invoice_notification(
+        'invoice_payment_reminder',
+        invoice,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued invoice payment reminder for customer #{invoice.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_invoice_variables(invoice)
@@ -366,7 +455,25 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless invoice.tenant_customer.can_receive_sms?(:payment)
       Rails.logger.info "[SMS_SERVICE] Customer #{invoice.tenant_customer.id} not opted in for payment failed SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(invoice.tenant_customer, invoice.business, :invoice_payment_failed)
+        send_opt_in_invitation(invoice.tenant_customer, invoice.business, :invoice_payment_failed)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_invoice_variables(invoice)
+      variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}/pay", invoice_id: invoice.id)
+      variables[:payment_id] = payment.id if payment
+
+      queued_notification = PendingSmsNotification.queue_invoice_notification(
+        'invoice_payment_failed',
+        invoice,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued invoice payment failed for customer #{invoice.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_invoice_variables(invoice)
@@ -390,7 +497,24 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless order.tenant_customer.can_receive_sms?(:order)
       Rails.logger.info "[SMS_SERVICE] Customer #{order.tenant_customer.id} not opted in for order confirmation SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(order.tenant_customer, order.business, :order_confirmation)
+        send_opt_in_invitation(order.tenant_customer, order.business, :order_confirmation)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_order_variables(order)
+      variables[:link] = generate_sms_link(order.business, "/orders/#{order.id}", order_id: order.id)
+
+      queued_notification = PendingSmsNotification.queue_order_notification(
+        'order_confirmation',
+        order,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued order confirmation for customer #{order.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_order_variables(order)
@@ -413,7 +537,26 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless order.tenant_customer.can_receive_sms?(:order)
       Rails.logger.info "[SMS_SERVICE] Customer #{order.tenant_customer.id} not opted in for order status SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(order.tenant_customer, order.business, :order_status_update)
+        send_opt_in_invitation(order.tenant_customer, order.business, :order_status_update)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_order_variables(order)
+      variables[:status] = order.status.humanize
+      variables[:link] = generate_sms_link(order.business, "/orders/#{order.id}", order_id: order.id)
+      variables[:previous_status] = previous_status
+
+      queued_notification = PendingSmsNotification.queue_order_notification(
+        'order_status_update',
+        order,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued order status update for customer #{order.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_order_variables(order)
@@ -437,7 +580,25 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless order.tenant_customer.can_receive_sms?(:order)
       Rails.logger.info "[SMS_SERVICE] Customer #{order.tenant_customer.id} not opted in for refund confirmation SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(order.tenant_customer, order.business, :order_refund_confirmation)
+        send_opt_in_invitation(order.tenant_customer, order.business, :order_refund_confirmation)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_order_variables(order)
+      variables[:amount] = format_currency(payment.refunded_amount || payment.amount)
+      variables[:payment_id] = payment.id if payment
+
+      queued_notification = PendingSmsNotification.queue_order_notification(
+        'order_refund_confirmation',
+        order,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued order refund confirmation for customer #{order.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_order_variables(order)
@@ -460,7 +621,24 @@ class SmsService
     # Check TCPA compliance - customer must be opted in
     unless order.tenant_customer.can_receive_sms?(:subscription)
       Rails.logger.info "[SMS_SERVICE] Customer #{order.tenant_customer.id} not opted in for subscription order SMS"
-      return { success: false, error: "Customer not opted in for SMS notifications" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(order.tenant_customer, order.business, :subscription_order_created)
+        send_opt_in_invitation(order.tenant_customer, order.business, :subscription_order_created)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = build_order_variables(order)
+      variables[:link] = generate_sms_link(order.business, "/orders/#{order.id}", order_id: order.id)
+
+      queued_notification = PendingSmsNotification.queue_order_notification(
+        'subscription_order_created',
+        order,
+        variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued subscription order created for customer #{order.tenant_customer.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = build_order_variables(order)
@@ -540,7 +718,29 @@ class SmsService
     # Check TCPA compliance - customer must be opted in for marketing SMS
     unless recipient.can_receive_sms?(:marketing)
       Rails.logger.info "[SMS_SERVICE] Customer #{recipient.id} not opted in for marketing SMS"
-      return { success: false, error: "Customer not opted in for marketing SMS" }
+
+      # Try to send opt-in invitation if appropriate
+      if should_send_invitation?(recipient, campaign.business, :marketing_campaign)
+        send_opt_in_invitation(recipient, campaign.business, :marketing_campaign)
+      end
+
+      # Queue the notification for later delivery instead of failing
+      variables = {
+        business_name: campaign.business.name,
+        offer_text: campaign.content || 'Special offer available',
+        link: generate_sms_link(campaign.business, '/', marketing_campaign_id: campaign.id)
+      }
+
+      queued_notification = PendingSmsNotification.queue_notification(
+        notification_type: 'marketing_campaign',
+        customer: recipient,
+        business: campaign.business,
+        sms_type: 'marketing',
+        template_data: variables
+      )
+
+      Rails.logger.info "[SMS_SERVICE] Queued marketing campaign for customer #{recipient.id} (notification #{queued_notification.id})"
+      return { success: false, error: "Customer not opted in for SMS notifications", queued: true, notification_id: queued_notification.id }
     end
     
     variables = {

--- a/app/services/sms_service.rb
+++ b/app/services/sms_service.rb
@@ -120,6 +120,11 @@ class SmsService
     variables[:link] = generate_sms_link(booking.business, "/booking/#{booking.id}/confirmation", booking_id: booking.id)
 
     message = Sms::MessageTemplates.render('booking.confirmation', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render booking confirmation template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(booking.tenant_customer.phone, message, {
       tenant_customer_id: booking.tenant_customer.id,
       booking_id: booking.id,
@@ -191,6 +196,11 @@ class SmsService
     variables[:link] = generate_sms_link(booking.business, "/booking/#{booking.id}/confirmation", booking_id: booking.id)
 
     message = Sms::MessageTemplates.render('booking.status_update', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render booking status update template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(booking.tenant_customer.phone, message, {
       tenant_customer_id: booking.tenant_customer.id,
       booking_id: booking.id,
@@ -210,6 +220,11 @@ class SmsService
     variables[:link] = generate_sms_link(booking.business, "/services", booking_id: booking.id)
     
     message = Sms::MessageTemplates.render('booking.cancellation', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render booking cancellation template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(booking.tenant_customer.phone, message, {
       tenant_customer_id: booking.tenant_customer.id,
       booking_id: booking.id,
@@ -229,6 +244,11 @@ class SmsService
     variables[:link] = generate_sms_link(booking.business, "/booking/#{booking.id}/pay", booking_id: booking.id)
     
     message = Sms::MessageTemplates.render('booking.payment_reminder', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render booking payment reminder template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(booking.tenant_customer.phone, message, {
       tenant_customer_id: booking.tenant_customer.id,
       booking_id: booking.id,
@@ -247,6 +267,11 @@ class SmsService
     variables[:link] = generate_sms_link(booking.business, "/booking/#{booking.id}/confirmation", booking_id: booking.id)
     
     message = Sms::MessageTemplates.render('booking.subscription_booking_created', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render subscription booking created template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(booking.tenant_customer.phone, message, {
       tenant_customer_id: booking.tenant_customer.id,
       booking_id: booking.id,
@@ -278,6 +303,11 @@ class SmsService
     variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}/pay", invoice_id: invoice.id)
 
     message = Sms::MessageTemplates.render('invoice.created', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render invoice created template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(invoice.tenant_customer.phone, message, {
       tenant_customer_id: invoice.tenant_customer.id,
       invoice_id: invoice.id,
@@ -296,6 +326,11 @@ class SmsService
     variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}", invoice_id: invoice.id)
     
     message = Sms::MessageTemplates.render('invoice.payment_confirmation', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render invoice payment confirmation template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(invoice.tenant_customer.phone, message, {
       tenant_customer_id: invoice.tenant_customer.id,
       invoice_id: invoice.id,
@@ -315,6 +350,11 @@ class SmsService
     variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}/pay", invoice_id: invoice.id)
     
     message = Sms::MessageTemplates.render('invoice.payment_reminder', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render invoice payment reminder template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(invoice.tenant_customer.phone, message, {
       tenant_customer_id: invoice.tenant_customer.id,
       invoice_id: invoice.id,
@@ -333,6 +373,11 @@ class SmsService
     variables[:link] = generate_sms_link(invoice.business, "/invoices/#{invoice.id}/pay", invoice_id: invoice.id)
     
     message = Sms::MessageTemplates.render('invoice.payment_failed', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render invoice payment failed template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(invoice.tenant_customer.phone, message, {
       tenant_customer_id: invoice.tenant_customer.id,
       invoice_id: invoice.id,
@@ -352,6 +397,11 @@ class SmsService
     variables[:link] = generate_sms_link(order.business, "/orders/#{order.id}", order_id: order.id)
     
     message = Sms::MessageTemplates.render('order.confirmation', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render order confirmation template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(order.tenant_customer.phone, message, {
       tenant_customer_id: order.tenant_customer.id,
       order_id: order.id,
@@ -371,6 +421,11 @@ class SmsService
     variables[:link] = generate_sms_link(order.business, "/orders/#{order.id}", order_id: order.id)
     
     message = Sms::MessageTemplates.render('order.status_update', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render order status update template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(order.tenant_customer.phone, message, {
       tenant_customer_id: order.tenant_customer.id,
       order_id: order.id,
@@ -389,6 +444,11 @@ class SmsService
     variables[:amount] = format_currency(payment.refunded_amount || payment.amount)
     
     message = Sms::MessageTemplates.render('order.refund_confirmation', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render order refund confirmation template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(order.tenant_customer.phone, message, {
       tenant_customer_id: order.tenant_customer.id,
       order_id: order.id,
@@ -407,6 +467,11 @@ class SmsService
     variables[:link] = generate_sms_link(order.business, "/orders/#{order.id}", order_id: order.id)
     
     message = Sms::MessageTemplates.render('order.subscription_order_created', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render subscription order created template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(order.tenant_customer.phone, message, {
       tenant_customer_id: order.tenant_customer.id,
       order_id: order.id,
@@ -420,6 +485,11 @@ class SmsService
     variables[:customer_name] = booking.tenant_customer.full_name
     
     message = Sms::MessageTemplates.render('business.new_booking_notification', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render business new booking notification template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(business_user.phone, message, {
       user_id: business_user.id,
       booking_id: booking.id,
@@ -432,6 +502,11 @@ class SmsService
     variables[:customer_name] = order.tenant_customer.full_name
     
     message = Sms::MessageTemplates.render('business.new_order_notification', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render business new order notification template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(business_user.phone, message, {
       user_id: business_user.id,
       order_id: order.id,
@@ -448,6 +523,11 @@ class SmsService
     }
     
     message = Sms::MessageTemplates.render('business.payment_received_notification', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render business payment received notification template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(business_user.phone, message, {
       user_id: business_user.id,
       payment_id: payment.id,
@@ -470,6 +550,11 @@ class SmsService
     }
     
     message = Sms::MessageTemplates.render('marketing.campaign_promotional', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render marketing campaign promotional template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(recipient.phone, message, {
       tenant_customer_id: recipient.id,
       marketing_campaign_id: campaign.id,
@@ -485,6 +570,11 @@ class SmsService
     }
     
     message = Sms::MessageTemplates.render('business.new_customer_notification', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render business new customer notification template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
+
     send_message_with_rate_limit(business_user.phone, message, {
       user_id: business_user.id,
       tenant_customer_id: customer.id,
@@ -505,6 +595,10 @@ class SmsService
 
     # Render the message using existing template system
     message = Sms::MessageTemplates.render('review_request.google_review_request', variables)
+    unless message
+      Rails.logger.error "[SMS_SERVICE] Failed to render review request template"
+      return { success: false, error: "Failed to render SMS template" }
+    end
 
     send_message_with_rate_limit(
       customer.phone,

--- a/db/migrate/20251004001352_create_pending_sms_notifications.rb
+++ b/db/migrate/20251004001352_create_pending_sms_notifications.rb
@@ -1,0 +1,43 @@
+class CreatePendingSmsNotifications < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pending_sms_notifications do |t|
+      # Required references
+      t.references :business, null: false, foreign_key: true
+      t.references :tenant_customer, null: false, foreign_key: true
+
+      # Optional references for specific notification types
+      t.references :booking, null: true, foreign_key: true
+      t.references :invoice, null: true, foreign_key: true
+      t.references :order, null: true, foreign_key: true
+
+      # Notification details
+      t.string :notification_type, null: false # 'booking_confirmation', 'invoice_created', etc.
+      t.string :sms_type, null: false # 'booking', 'payment', 'order', etc.
+      t.json :template_data, null: false # Variables for SMS template rendering
+      t.text :phone_number, null: false # Store phone number for safety
+
+      # Lifecycle tracking
+      t.datetime :queued_at, null: false
+      t.datetime :expires_at, null: false # Auto-expire old notifications (7 days)
+      t.datetime :processed_at, null: true # When the notification was sent/processed
+      t.datetime :failed_at, null: true # If processing failed
+      t.text :failure_reason, null: true # Why processing failed
+
+      # Status tracking
+      t.string :status, default: 'pending' # 'pending', 'sent', 'failed', 'expired'
+
+      # Prevent duplicates
+      t.string :deduplication_key, null: false # Unique key to prevent duplicate queuing
+
+      t.timestamps
+    end
+
+    # Indexes for performance
+    add_index :pending_sms_notifications, [:business_id, :tenant_customer_id]
+    add_index :pending_sms_notifications, [:status, :queued_at]
+    add_index :pending_sms_notifications, [:expires_at]
+    add_index :pending_sms_notifications, [:deduplication_key], unique: true
+    add_index :pending_sms_notifications, [:notification_type]
+    add_index :pending_sms_notifications, [:phone_number]
+  end
+end

--- a/db/migrate/20251004005649_fix_pending_sms_notifications_foreign_keys.rb
+++ b/db/migrate/20251004005649_fix_pending_sms_notifications_foreign_keys.rb
@@ -1,0 +1,27 @@
+class FixPendingSmsNotificationsForeignKeys < ActiveRecord::Migration[8.0]
+  def up
+    # Remove existing foreign key constraints for business and tenant_customer
+    remove_foreign_key :pending_sms_notifications, :businesses
+    remove_foreign_key :pending_sms_notifications, :tenant_customers
+
+    # Add foreign key constraints with cascade deletion
+    # When business is deleted, all its pending notifications should be deleted
+    add_foreign_key :pending_sms_notifications, :businesses, on_delete: :cascade
+
+    # When tenant_customer is deleted, all their pending notifications should be deleted
+    add_foreign_key :pending_sms_notifications, :tenant_customers, on_delete: :cascade
+
+    # Note: Keep booking, invoice, order foreign keys as-is (restrict)
+    # We want to preserve notifications even if specific bookings/invoices/orders are deleted
+  end
+
+  def down
+    # Remove cascade foreign keys
+    remove_foreign_key :pending_sms_notifications, :businesses
+    remove_foreign_key :pending_sms_notifications, :tenant_customers
+
+    # Restore original restrict foreign keys
+    add_foreign_key :pending_sms_notifications, :businesses
+    add_foreign_key :pending_sms_notifications, :tenant_customers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_04_001352) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_04_005649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -803,7 +803,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_001352) do
     t.index ["tenant_customer_id", "created_at"], name: "index_orders_on_tenant_customer_id_and_created_at"
     t.index ["tenant_customer_id"], name: "index_orders_on_tenant_customer_id"
     t.index ["tip_amount"], name: "index_orders_on_tip_amount"
-    t.check_constraint "status::text = ANY (ARRAY['pending_payment'::character varying::text, 'paid'::character varying::text, 'cancelled'::character varying::text, 'shipped'::character varying::text, 'refunded'::character varying::text, 'processing'::character varying::text, 'completed'::character varying::text, 'business_deleted'::character varying::text])", name: "status_enum_check"
+    t.check_constraint "status::text = ANY (ARRAY['pending_payment'::character varying, 'paid'::character varying, 'cancelled'::character varying, 'shipped'::character varying, 'refunded'::character varying, 'processing'::character varying, 'completed'::character varying, 'business_deleted'::character varying]::text[])", name: "status_enum_check"
   end
 
   create_table "page_sections", force: :cascade do |t|
@@ -1799,10 +1799,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_001352) do
   add_foreign_key "payments", "orders", on_delete: :nullify
   add_foreign_key "payments", "tenant_customers", on_delete: :nullify
   add_foreign_key "pending_sms_notifications", "bookings"
-  add_foreign_key "pending_sms_notifications", "businesses"
+  add_foreign_key "pending_sms_notifications", "businesses", on_delete: :cascade
   add_foreign_key "pending_sms_notifications", "invoices"
   add_foreign_key "pending_sms_notifications", "orders"
-  add_foreign_key "pending_sms_notifications", "tenant_customers"
+  add_foreign_key "pending_sms_notifications", "tenant_customers", on_delete: :cascade
   add_foreign_key "platform_discount_codes", "businesses", on_delete: :cascade
   add_foreign_key "platform_loyalty_transactions", "businesses", on_delete: :cascade
   add_foreign_key "platform_loyalty_transactions", "platform_referrals", column: "related_platform_referral_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_02_200002) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_04_001352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"
   enable_extension "pg_catalog.plpgsql"
@@ -904,6 +904,38 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_02_200002) do
     t.index ["tip_amount"], name: "index_payments_on_tip_amount"
   end
 
+  create_table "pending_sms_notifications", force: :cascade do |t|
+    t.bigint "business_id", null: false
+    t.bigint "tenant_customer_id", null: false
+    t.bigint "booking_id"
+    t.bigint "invoice_id"
+    t.bigint "order_id"
+    t.string "notification_type", null: false
+    t.string "sms_type", null: false
+    t.json "template_data", null: false
+    t.text "phone_number", null: false
+    t.datetime "queued_at", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "processed_at"
+    t.datetime "failed_at"
+    t.text "failure_reason"
+    t.string "status", default: "pending"
+    t.string "deduplication_key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["booking_id"], name: "index_pending_sms_notifications_on_booking_id"
+    t.index ["business_id", "tenant_customer_id"], name: "idx_on_business_id_tenant_customer_id_7f0c30b769"
+    t.index ["business_id"], name: "index_pending_sms_notifications_on_business_id"
+    t.index ["deduplication_key"], name: "index_pending_sms_notifications_on_deduplication_key", unique: true
+    t.index ["expires_at"], name: "index_pending_sms_notifications_on_expires_at"
+    t.index ["invoice_id"], name: "index_pending_sms_notifications_on_invoice_id"
+    t.index ["notification_type"], name: "index_pending_sms_notifications_on_notification_type"
+    t.index ["order_id"], name: "index_pending_sms_notifications_on_order_id"
+    t.index ["phone_number"], name: "index_pending_sms_notifications_on_phone_number"
+    t.index ["status", "queued_at"], name: "index_pending_sms_notifications_on_status_and_queued_at"
+    t.index ["tenant_customer_id"], name: "index_pending_sms_notifications_on_tenant_customer_id"
+  end
+
   create_table "platform_discount_codes", force: :cascade do |t|
     t.bigint "business_id", null: false
     t.string "code", null: false
@@ -1766,6 +1798,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_02_200002) do
   add_foreign_key "payments", "invoices", on_delete: :nullify
   add_foreign_key "payments", "orders", on_delete: :nullify
   add_foreign_key "payments", "tenant_customers", on_delete: :nullify
+  add_foreign_key "pending_sms_notifications", "bookings"
+  add_foreign_key "pending_sms_notifications", "businesses"
+  add_foreign_key "pending_sms_notifications", "invoices"
+  add_foreign_key "pending_sms_notifications", "orders"
+  add_foreign_key "pending_sms_notifications", "tenant_customers"
   add_foreign_key "platform_discount_codes", "businesses", on_delete: :cascade
   add_foreign_key "platform_loyalty_transactions", "businesses", on_delete: :cascade
   add_foreign_key "platform_loyalty_transactions", "platform_referrals", column: "related_platform_referral_id"

--- a/lib/sms/message_templates.yml
+++ b/lib/sms/message_templates.yml
@@ -4,7 +4,7 @@
 booking:
   confirmation: "✅ Booking confirmed! %SERVICE_NAME% on %DATE% at %TIME% with %BUSINESS_NAME%. Details: %LINK%"
   cancellation: "❌ Booking cancelled: %DATE% at %TIME%. Reason: %REASON%. Reschedule: %LINK%"
-  reminder: "⏰ Reminder: %SERVICE_NAME% tomorrow at %TIME% with %BUSINESS_NAME%. Location: %ADDRESS%"
+  reminder: "⏰ Reminder: %SERVICE_NAME% %TIMEFRAME_TEXT% at %TIME% with %BUSINESS_NAME%. Reply HELP for assistance or CONFIRM to confirm."
   status_update: "📝 Booking updated: %SERVICE_NAME% now %DATE% at %TIME%. Changes: %LINK%"
   payment_reminder: "💳 Payment due: $%AMOUNT% for %SERVICE_NAME% on %DATE%. Pay now: %LINK%"
   subscription_booking_created: "📅 Subscription booking scheduled: %SERVICE_NAME% on %DATE% at %TIME%. Details: %LINK%"

--- a/lib/tasks/fix_user_customer_phone_sync.rb
+++ b/lib/tasks/fix_user_customer_phone_sync.rb
@@ -1,0 +1,136 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Script to fix phone number mismatches between User and TenantCustomer records
+# Run this in production to sync User phone numbers to their linked TenantCustomer records
+
+class UserCustomerPhoneSync
+  def self.run(dry_run: true)
+    puts "=== User to TenantCustomer Phone Sync #{dry_run ? '(DRY RUN)' : '(LIVE RUN)'} ==="
+    puts "Starting at: #{Time.current}"
+    puts
+
+    mismatched_customers = []
+    updated_count = 0
+    error_count = 0
+
+    # Find all TenantCustomers linked to Users where phone numbers differ
+    TenantCustomer.joins(:user).find_each do |customer|
+      user = customer.user
+
+      # Skip if user doesn't have a phone
+      next unless user.phone.present?
+
+      # Check if phones are different
+      if customer.phone != user.phone
+        mismatched_customers << {
+          customer_id: customer.id,
+          user_id: user.id,
+          business_name: customer.business.name,
+          user_email: user.email,
+          customer_phone: customer.phone,
+          user_phone: user.phone,
+          customer_opt_in: customer.phone_opt_in?,
+          user_opt_in: user.respond_to?(:phone_opt_in?) ? user.phone_opt_in? : false
+        }
+      end
+    end
+
+    puts "Found #{mismatched_customers.count} TenantCustomers with phone mismatches:"
+    puts
+
+    mismatched_customers.each do |mismatch|
+      puts "Customer ID: #{mismatch[:customer_id]} | User: #{mismatch[:user_email]} | Business: #{mismatch[:business_name]}"
+      puts "  Customer Phone: #{mismatch[:customer_phone]} (opt-in: #{mismatch[:customer_opt_in]})"
+      puts "  User Phone:     #{mismatch[:user_phone]} (opt-in: #{mismatch[:user_opt_in]})"
+      puts
+
+      unless dry_run
+        begin
+          customer = TenantCustomer.find(mismatch[:customer_id])
+          user = User.find(mismatch[:user_id])
+
+          # Use CustomerLinker to sync the data properly
+          linker = CustomerLinker.new(customer.business)
+          linker.sync_user_data_to_customer(user, customer)
+
+          updated_count += 1
+          puts "  ✅ UPDATED: Customer phone synced to #{user.phone}"
+        rescue => e
+          error_count += 1
+          puts "  ❌ ERROR: #{e.message}"
+        end
+        puts
+      end
+    end
+
+    puts "=== Summary ==="
+    puts "Total mismatched records: #{mismatched_customers.count}"
+    if dry_run
+      puts "This was a DRY RUN - no changes were made"
+      puts "Run with dry_run: false to apply changes"
+    else
+      puts "Records updated: #{updated_count}"
+      puts "Errors encountered: #{error_count}"
+    end
+    puts "Completed at: #{Time.current}"
+  end
+
+  # Fix a specific user's phone sync
+  def self.fix_user(user_email, dry_run: true)
+    puts "=== Fixing phone sync for user: #{user_email} #{dry_run ? '(DRY RUN)' : '(LIVE RUN)'} ==="
+
+    user = User.find_by(email: user_email)
+    unless user
+      puts "❌ User not found: #{user_email}"
+      return
+    end
+
+    puts "User: #{user.email} | Phone: #{user.phone} | Opt-in: #{user.respond_to?(:phone_opt_in?) ? user.phone_opt_in? : 'N/A'}"
+    puts
+
+    # Find all TenantCustomer records linked to this user
+    customers = TenantCustomer.where(user_id: user.id)
+    puts "Found #{customers.count} linked TenantCustomer records:"
+    puts
+
+    customers.each do |customer|
+      puts "Business: #{customer.business.name} | Customer Phone: #{customer.phone} | Opt-in: #{customer.phone_opt_in?}"
+
+      if customer.phone != user.phone
+        puts "  🔄 Phone mismatch detected"
+        unless dry_run
+          begin
+            linker = CustomerLinker.new(customer.business)
+            linker.sync_user_data_to_customer(user, customer)
+            customer.reload
+            puts "  ✅ UPDATED: Customer phone synced to #{customer.phone}"
+          rescue => e
+            puts "  ❌ ERROR: #{e.message}"
+          end
+        end
+      else
+        puts "  ✅ Phone numbers already match"
+      end
+      puts
+    end
+
+    if dry_run
+      puts "This was a DRY RUN - no changes were made"
+      puts "Run with dry_run: false to apply changes"
+    end
+  end
+end
+
+# If running as a script
+if __FILE__ == $0
+  # Parse command line arguments
+  dry_run = !ARGV.include?('--live')
+  user_email = ARGV.find { |arg| arg.include?('@') }
+
+  if user_email
+    UserCustomerPhoneSync.fix_user(user_email, dry_run: dry_run)
+  else
+    UserCustomerPhoneSync.run(dry_run: dry_run)
+  end
+end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Queues SMS when customers aren’t opted in and auto-replays after opt-in; replaces ad-hoc customer creation with CustomerLinker; adds pending SMS infrastructure and tests.
> 
> - **SMS Notifications**:
>   - **Queue on no opt-in**: `SmsService` now queues `PendingSmsNotification` across booking/invoice/order/marketing sends instead of hard-failing; standardizes template rendering and basic error checks.
>   - **Auto-replay after opt-in**: Add `SmsNotificationReplayJob` and `SmsNotificationReplayService` to process queued messages with rate limiting and retries.
>   - **Twilio Webhook**: On START/opt-in, schedules replay per customer/business; records invitation responses; adds helper `schedule_notification_replay`.
>   - **Templates/Specs**: Update `booking.reminder` template (uses `TIMEFRAME_TEXT`); expand specs to cover queuing behavior and template usage.
> - **Data Model & Migrations**:
>   - New model `PendingSmsNotification` with associations, statuses, scopes, deduplication, and management helpers.
>   - Migrations to create table, add indexes, and cascade FKs; schema updated.
> - **Customer Linking**:
>   - Replace manual customer creation/updates with `CustomerLinker` in `Public::OrdersController` and `Public::SubscriptionsController` (with error handling).
>   - `ReferralService` uses `CustomerLinker` to find/link tenant customers.
>   - Improve `CustomerLinker#sync_user_data_to_customer` and `User#sync_phone_to_tenant_customers` to sync phone and opt-in state.
> - **Utilities**:
>   - Add script `lib/tasks/fix_user_customer_phone_sync.rb` to reconcile user/customer phone mismatches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 699e64ce5dfa711b0e7724df8dd7ac329487cefb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->