### PR TITLE
fix: update sign-up link for business accounts in home page

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -573,7 +573,7 @@
 
     <!-- CTA -->
     <div class="text-center">
-      <a href="/businesses/sign_up" class="inline-flex items-center px-8 py-4 bg-secondary hover:bg-primary text-white font-bold rounded-lg shadow-lg hover:shadow-xl transition-all transform hover:-translate-y-1">
+      <a href="/business/sign_up" class="inline-flex items-center px-8 py-4 bg-secondary hover:bg-primary text-white font-bold rounded-lg shadow-lg hover:shadow-xl transition-all transform hover:-translate-y-1">
         Start Business Account
         <svg class="w-5 h-5 ml-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single marketing link fix with no auth or backend changes; wrong URL could have caused 404s for that CTA before.
> 
> **Overview**
> Fixes the **Start Business Account** link in the analytics section so it points to **`/business/sign_up`** instead of **`/businesses/sign_up`**, matching the app’s registered business registration route (same path used elsewhere on the home page via `new_business_registration_path`).
> 
> This is a one-line `href` change on the analytics showcase CTA only; no other markup or behavior is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 531c6fbe338a3f16d4adb19c708dc472c078ab0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->