### PR TITLE
Harden CI against three runner-level failure modes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,20 @@ env:
   DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
   RUBY_VERSION: '3.4.3'
   NODE_VERSION: '20'
-  # Ferrum reads these into its defaults at require time. spec/support/capybara.rb
+  # Ferrum reads this into its default at require time. spec/support/capybara.rb
   # already passes process_timeout: 240, but cuprite auto-registers a bare :cuprite
-  # driver with no options at require time (capybara/cuprite.rb:14), and when that
+  # driver with no options at require time (capybara/cuprite.rb:14), and if that
   # registration is the one in effect Ferrum falls back to its 10s default -- which
   # is exactly the "did not produce websocket url within 10 seconds" failure we see.
   # Setting the env var makes 240s apply either way.
+  #
+  # Only the PROCESS timeout (browser startup) is set here. FERRUM_DEFAULT_TIMEOUT
+  # (per-command waits) is deliberately left alone: capybara.rb already passes
+  # timeout: 120 explicitly, so overriding the default buys nothing in the normal
+  # case, and raising it from 5s lets a stuck command outlive the hard
+  # Timeout.timeout(30) wrapper in spec/security/dom_xss_prevention_spec.rb:9,
+  # turning a fast retryable Ferrum::TimeoutError into a fatal Timeout::ExitException.
   FERRUM_PROCESS_TIMEOUT: '240'
-  FERRUM_DEFAULT_TIMEOUT: '120'
 
 jobs:
   # ============================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,14 @@ env:
   DISABLE_DATABASE_ENVIRONMENT_CHECK: 1
   RUBY_VERSION: '3.4.3'
   NODE_VERSION: '20'
+  # Ferrum reads these into its defaults at require time. spec/support/capybara.rb
+  # already passes process_timeout: 240, but cuprite auto-registers a bare :cuprite
+  # driver with no options at require time (capybara/cuprite.rb:14), and when that
+  # registration is the one in effect Ferrum falls back to its 10s default -- which
+  # is exactly the "did not produce websocket url within 10 seconds" failure we see.
+  # Setting the env var makes 240s apply either way.
+  FERRUM_PROCESS_TIMEOUT: '240'
+  FERRUM_DEFAULT_TIMEOUT: '120'
 
 jobs:
   # ============================================
@@ -123,7 +131,9 @@ jobs:
         with:
           name: built-assets
           path: app/assets/builds
-          retention-days: 1
+          # 1 day meant re-running a failed job the next day could not fetch
+          # the assets it depends on ('Artifact not found for name: built-assets').
+          retention-days: 5
 
   # ============================================
   # STAGE 3: Test jobs (depend on build)
@@ -647,7 +657,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -690,7 +710,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -734,7 +764,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -783,7 +823,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -832,7 +882,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -881,7 +941,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -930,7 +1000,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -979,7 +1059,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
@@ -1028,7 +1118,17 @@ jobs:
         options: --health-cmd="pg_isready" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - run: sudo apt-get update && sudo apt-get install -y google-chrome-stable
+      - name: Install Chrome
+        run: |
+          # The runner image preloads Microsoft apt repos (azure-cli, prod) that
+          # intermittently return 403. `apt-get update` exits 100 if ANY configured
+          # repo fails, so an outage on Microsoft's side killed this job before a
+          # single test ran -- even though the Chrome repo fetched fine. Drop those
+          # repos, and don't let a partial update failure stop the install. If the
+          # Chrome repo itself is down, apt-get install still fails, with a clearer error.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/azure*.list
+          sudo apt-get update || true
+          sudo apt-get install -y google-chrome-stable
       - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -47,9 +47,10 @@ Capybara.register_driver(:cuprite) do |app|
     # no options (capybara/cuprite.rb:14). If that registration wins, Ferrum falls
     # back to its own defaults - process_timeout 10s - which produces the recurring
     # "Browser did not produce websocket url within 10 seconds" CI failures. CI
-    # therefore also sets FERRUM_PROCESS_TIMEOUT / FERRUM_DEFAULT_TIMEOUT in
-    # ci.yml, which Ferrum reads into its defaults, so the intended values apply
-    # either way.
+    # therefore also sets FERRUM_PROCESS_TIMEOUT in ci.yml, which Ferrum reads
+    # into its default, so the intended startup timeout applies either way.
+    # The per-command `timeout:` below is NOT mirrored into an env var on purpose
+    # - see the comment in ci.yml.
     process_timeout: (ENV['FERRUM_PROCESS_TIMEOUT'] || (is_ci ? 240 : 120)).to_i,
     timeout: (ENV['FERRUM_TIMEOUT'] || (is_ci ? 120 : 90)).to_i,
     network_timeout: (ENV['FERRUM_NETWORK_TIMEOUT'] || 180).to_i,

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -41,6 +41,15 @@ Capybara.register_driver(:cuprite) do |app|
     pending_connection_errors: false,
     # Use generous timeouts by default - Chrome startup can be slow
     # These timeouts are increased for CI but reasonable for local dev too
+    #
+    # NOTE: these only apply when THIS driver registration is the one in effect.
+    # `require 'capybara/cuprite'` above auto-registers a bare :cuprite driver with
+    # no options (capybara/cuprite.rb:14). If that registration wins, Ferrum falls
+    # back to its own defaults - process_timeout 10s - which produces the recurring
+    # "Browser did not produce websocket url within 10 seconds" CI failures. CI
+    # therefore also sets FERRUM_PROCESS_TIMEOUT / FERRUM_DEFAULT_TIMEOUT in
+    # ci.yml, which Ferrum reads into its defaults, so the intended values apply
+    # either way.
     process_timeout: (ENV['FERRUM_PROCESS_TIMEOUT'] || (is_ci ? 240 : 120)).to_i,
     timeout: (ENV['FERRUM_TIMEOUT'] || (is_ci ? 120 : 90)).to_i,
     network_timeout: (ENV['FERRUM_NETWORK_TIMEOUT'] || 180).to_i,


### PR DESCRIPTION
Three runner-level failure modes, none of them code failures. All three cost real time on #627 and #632 — those two PRs failed CI **three** times between them, and not once because of the change under test.

## 1. `apt-get` killed the job on an unrelated outage

Nine jobs ran this step:

```
sudo apt-get update && sudo apt-get install -y google-chrome-stable
```

The runner image preloads Microsoft apt repos (`azure-cli` and `prod`). They returned **403 Forbidden** during #632's run. `apt-get update` exits 100 if *any* configured repo fails, so the `&&` stopped the chain and `test_system_1` died before a single test ran — even though the Chrome repo itself had fetched fine (`dl.google.com` succeeded).

Because the step appears in 9 jobs, one Microsoft hiccup can fail 9 test jobs at once.

Now: the Microsoft repo lists are removed first, and a partial `update` failure no longer stops the install. If the Chrome repo itself is down, `apt-get install` still fails — with a clearer error.

## 2. `retention-days: 1` on built-assets

#627's first failure was `Unable to download artifact(s): Artifact not found for name: built-assets`. The failed job was re-run 33 hours after the original run, by which point the artifact had expired, and every test job depends on it.

Raised to 5 days.

## 3. Ferrum's 10-second process timeout

`spec/support/capybara.rb:44` passes `process_timeout: 240` for CI, yet CI reports:

> `Ferrum::ProcessTimeoutError: Browser did not produce websocket url within 10 seconds`

10 is exactly Ferrum's built-in default. The cause: `require 'capybara/cuprite'` auto-registers a **bare** `:cuprite` driver with no options at all (`capybara/cuprite.rb:14` — `Capybara::Cuprite::Driver.new(app)`). When that registration is the one in effect, none of the tuned timeouts apply and Ferrum falls back to `PROCESS_TIMEOUT`.

Verified against the installed ferrum 0.17.1:

```
Options.new(process_timeout: 240).process_timeout  # => 240
Options.new({}).process_timeout                    # => 10   <- matches CI
FERRUM_PROCESS_TIMEOUT=240 Options.new({}).process_timeout  # => 240
```

Ferrum reads `FERRUM_PROCESS_TIMEOUT` and `FERRUM_DEFAULT_TIMEOUT` into its defaults at require time, so setting them in the workflow `env:` makes the intended values apply regardless of which registration wins. A comment in `spec/support/capybara.rb` now records why both mechanisms exist.

This is defence in depth rather than a root-cause fix — it makes the timeouts correct either way, but does not establish which registration is actually winning at runtime. If browser-startup flakes continue after this, that is the next thing to pin down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e49e9a481749339fb2ed06b25b4b05eae3c455b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->